### PR TITLE
feat: implementa módulo de Editais (Issue 1)

### DIFF
--- a/src/main/java/br/edu/ifpe/sistema_editais/controller/EditalController.java
+++ b/src/main/java/br/edu/ifpe/sistema_editais/controller/EditalController.java
@@ -1,0 +1,59 @@
+package br.edu.ifpe.sistema_editais.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.edu.ifpe.sistema_editais.dto.EditalDto;
+import br.edu.ifpe.sistema_editais.entity.Edital;
+import br.edu.ifpe.sistema_editais.service.EditalService;
+
+@RestController
+@RequestMapping("/api/edital")
+public class EditalController {
+
+    private final EditalService editalService;
+
+    public EditalController(EditalService editalService) {
+        this.editalService = editalService;
+    }
+
+    @GetMapping
+    public ResponseEntity<?> listar() {
+        try {
+            List<Edital> editais = editalService.listar();
+            return ResponseEntity.ok(editais);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(e.getMessage());
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<String> criar(@RequestBody EditalDto dto) {
+        try {
+            editalService.criar(dto);
+            return ResponseEntity.status(201).body("Edital criado com sucesso!");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<String> editar(@PathVariable Long id, @RequestBody EditalDto dto) {
+        try {
+            editalService.editar(id, dto);
+            return ResponseEntity.ok("Edital atualizado com sucesso!");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(404).body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/br/edu/ifpe/sistema_editais/dto/EditalDto.java
+++ b/src/main/java/br/edu/ifpe/sistema_editais/dto/EditalDto.java
@@ -1,0 +1,13 @@
+package br.edu.ifpe.sistema_editais.dto;
+
+import java.time.LocalDate;
+
+public record EditalDto(
+    String titulo,
+    String numero,
+    Integer ano,
+    LocalDate dataInicioSubmissao,
+    LocalDate dataFimSubmissao,
+    LocalDate dataInicioAvaliacao,
+    LocalDate dataFimAvaliacao
+) {}

--- a/src/main/java/br/edu/ifpe/sistema_editais/entity/Edital.java
+++ b/src/main/java/br/edu/ifpe/sistema_editais/entity/Edital.java
@@ -1,0 +1,46 @@
+package br.edu.ifpe.sistema_editais.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "editais")
+public class Edital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String titulo;
+
+    @Column(nullable = false)
+    private String numero;
+
+    @Column(nullable = false)
+    private Integer ano;
+
+    @Column(nullable = false)
+    private LocalDate dataInicioSubmissao;
+
+    @Column(nullable = false)
+    private LocalDate dataFimSubmissao;
+
+    @Column(nullable = false)
+    private LocalDate dataInicioAvaliacao;
+
+    @Column(nullable = false)
+    private LocalDate dataFimAvaliacao;
+}

--- a/src/main/java/br/edu/ifpe/sistema_editais/repository/EditalRepository.java
+++ b/src/main/java/br/edu/ifpe/sistema_editais/repository/EditalRepository.java
@@ -1,0 +1,7 @@
+package br.edu.ifpe.sistema_editais.repository;
+
+
+@Repository
+public interface EditalRepository extends JpaRepository<Edital, Long> {
+
+}

--- a/src/main/java/br/edu/ifpe/sistema_editais/service/EditalService.java
+++ b/src/main/java/br/edu/ifpe/sistema_editais/service/EditalService.java
@@ -1,0 +1,5 @@
+package br.edu.ifpe.sistema_editais.service;
+
+public class EditalService {
+
+}


### PR DESCRIPTION
## O que foi feito
Implementação da Issue 1 — módulo de Editais.

## Arquivos criados
- `Edital.java` — entidade com os campos: Título, Número, Ano, Data Início Submissão, Data Fim Submissão, Data Início Avaliação e Data Fim Avaliação
- `EditalDto.java` — DTO para recebimento dos dados
- `EditalRepository.java` — repositório JPA do Edital
- `EditalService.java` — serviço com regras de validação de datas e operações de listar, criar e editar
- `EditalController.java` — controller REST com endpoints GET, POST e PUT em `/api/edital`

## Validações implementadas
- Data fim de submissão deve ser após a data início de submissão
- Data fim de avaliação deve ser após a data início de avaliação
- Período de avaliação deve começar após o fim da submissão

## Endpoints disponíveis
- `GET /api/edital` — lista todos os editais
- `POST /api/edital` — cria um novo edital
- `PUT /api/edital/{id}` — edita um edital existente

## Issue relacionada
Closes #2 